### PR TITLE
Avoid triggering "gcc internal compiler error"

### DIFF
--- a/NYTProf.xs
+++ b/NYTProf.xs
@@ -414,7 +414,7 @@ static HV *pkg_fids_hv;     /* currently just package names */
 #if (PERL_VERSION < 17) || ((PERL_VERSION == 17) && (PERL_SUBVERSION < 7)) || defined(PERL_SAWAMPERSAND)
 static U8 last_sawampersand;
 #define CHECK_SAWAMPERSAND(fid,line) STMT_START { \
-    if ((U8)PL_sawampersand != last_sawampersand) { \
+    if (PL_sawampersand != last_sawampersand) { \
         if (trace_level >= 1) \
             logwarn("Slow regex match variable seen (0x%x->0x%x at %u:%u)\n", PL_sawampersand, last_sawampersand, fid, line); \
         /* XXX this is a hack used by test14 to avoid different behaviour \


### PR DESCRIPTION
I'm not really sure you should care enough to apply this patch since it's really
gcc's or Redhat's fault — which they probably already have fixed.

Devel-NYTProf-4.09 (and later) fails to build on Fedora Core 4 with
perl-5.16.  Both perl-5.14 and perl-5.18-tobe avoids triggering this bug  (they both have different definition of PL_sawampersand from 5.16).

```
$ /opt/perl/bin/perl /opt/perl/lib/ExtUtils/xsubpp  -typemap /opt/perl/lib/ExtUtils/typemap -typemap typemap  NYTProf.xs > NYTProf.xsc && mv NYTProf.xsc NYTProf.c
gcc -c  -I../zlib -D_REENTRANT -D_GNU_SOURCE -DUSE_SITECUSTOMIZE -DPERL_RELOCATABLE_INCPUSH -fno-merge-constants -fno-strict-aliasing -pipe -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64 -O2   -DVERSION=\"5.00\" -DXS_VERSION=\"5.00\" -fPIC "-I/opt/perl/lib/CORE"  -DHAS_CLOCK_GETTIME -DHAS_ZLIB -DUSE_HARD_ASSERT -W -Wall -Wpointer-arith -Wbad-function-cast -Wno-comment -Wno-sign-compare -Wno-cast-qual -Wmissing-noreturn -Wno-unused-parameter NYTProf.c
NYTProf.xs: In function ‘DB_stmt’:
NYTProf.xs:1499: internal compiler error: in c_common_type, at c-typeck.c:530
Please submit a full bug report,
with preprocessed source if appropriate.
See <URL:http://bugzilla.redhat.com/bugzilla> for instructions.
Preprocessed source stored into /tmp/ccxpxams.out file, please attach this to your bugreport.
make: *** [NYTProf.o] Error 1

$ gcc --version
gcc (GCC) 4.0.2 20051125 (Red Hat 4.0.2-8)
Copyright (C) 2005 Free Software Foundation, Inc.

$ perl -v
This is perl 5, version 16, subversion 0 (v5.16.0) built for i686-linux-thread-multi
(with 1 registered patch, see perl -V for more detail)

Binary build 1600 [295848] provided by ActiveState http://www.ActiveState.com
Built May 31 2012 20:03:15
```
