### PR TITLE
Document --minimal in nytprofhtml's POD

### DIFF
--- a/bin/nytprofhtml
+++ b/bin/nytprofhtml
@@ -1964,6 +1964,10 @@ Make your web browser visit the report after it has been generated.
 
 If this doesn't work well for you, try installing the L<Browser::Open> module.
 
+=item -m, --minimal
+
+Don't generate graphviz .dot files or block/sub-level reports.
+
 =item --no-flame
 
 Disable generation of the framegraph on the index page.


### PR DESCRIPTION
Fixes RT #86039: nytprofhtml pod doesn't document --minimal
