### PR TITLE
[doc] Devel::NYTProf needs to be loaded as early as possible

### DIFF
--- a/lib/Devel/NYTProf.pm
+++ b/lib/Devel/NYTProf.pm
@@ -597,7 +597,9 @@ to stop collecting profile data, and calling DB::enable_profile() to start
 collecting profile data.
 
 Using the C<start=no> option lets you leave the profiler disabled initially
-until you call DB::enable_profile() at the right moment.
+until you call DB::enable_profile() at the right moment. You still need to
+load Devel::NYTProf as early as possible, even if you don't call
+DB::enable_profile() until much later.
 
 The profile output file can't be used until it's been properly completed and
 closed.  Calling DB::disable_profile() doesn't do that.  To make a profile file


### PR DESCRIPTION
... even if it is not used until later
