### PR TITLE
Add Version Badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Devel::NYTProf is a powerful feature-rich perl source code profiler.
 
+[![CPAN version](https://badge.fury.io/pl/Devel-NYTProf.svg)](http://badge.fury.io/pl/Devel-NYTProf)
 [![Build Status](https://secure.travis-ci.org/timbunce/devel-nytprof.png)](http://travis-ci.org/timbunce/devel-nytprof)
 
 For more information see:


### PR DESCRIPTION
Hello @timbunce.  We are making an effort to standardize the way developers discover CPAN distributions from Github repos.  We've had quite a bit of [success and support](http://badge.fury.io/projects) from package authors for other languages, and wanted to contribute to the Perl and CPAN community.

It looks a little different than the Travis CI old PNG badge until they switch to their [new design](http://blog.travis-ci.com/2014-03-20-build-status-badges-support-svg/).
