### PR TITLE
A test file for really long Moose subnames

### DIFF
--- a/t/73-moose-long-type-name.t
+++ b/t/73-moose-long-type-name.t
@@ -1,0 +1,88 @@
+use strict;
+use Test::More;
+
+use lib qw(t/lib);
+use NYTProfTest;
+
+eval "use Moose; 1" or plan skip_all => "Moose required";
+eval "use MooseX::Types::Moose; 1" or plan skip_all => "MooseX::Types::Moose required";
+eval "use MooseX::Types::Structured; 1" or plan skip_all => "MooseX::Types::Structured required";
+
+use Devel::NYTProf::Run qw(profile_this);
+
+my $src_code = join("", <DATA>);
+
+run_test_group( {
+    extra_options => {
+        start => 'begin', compress => 1, stmts => 0, slowops => 0,
+    },
+    extra_test_count => 2,
+    extra_test_code  => sub {
+        my ($profile, $env) = @_;
+
+        $profile = profile_this(
+            src_code => $src_code,
+            out_file => $env->{file},
+            skip_sitecustomize => 1,
+            htmlopen => $ENV{NYTPROF_TEST_HTMLOPEN},
+        );
+        isa_ok $profile, 'Devel::NYTProf::Data';
+
+        my $subs = $profile->subname_subinfo_map;
+
+        ok 1;
+    },
+});
+
+__DATA__
+#!perl
+package Class;
+use strict;
+use warnings;
+use Moose;
+use MooseX::Types::Moose qw(:all);
+use MooseX::Types::Structured qw(
+    Dict
+    Map
+    Optional
+    Tuple
+);
+
+has some_attribute => (
+    is  => "ro",
+    isa => Maybe[
+        Dict[
+            some => Int,
+            really => ArrayRef[
+                Dict[
+                    long      => Optional[Int],
+                    typecheck => Optional[Str],
+                    that      => Optional[Str],
+                    seems     => Optional[Str],
+                    to        => Optional[Str],
+                    go        => Optional[Str],
+                    on        => Optional[Int],
+                    forever   => Optional[Str],
+                    and       => Optional[Bool],
+                    just      => Optional[Int],
+                    never     => Optional[Str],
+                    stops     => Optional[Maybe[Str]],
+                    this      => Optional[Int],
+                    used      => Optional[Int],
+                    to        => Optional[Int],
+                    cause     => Optional[Int],
+                    a         => Optional[Int],
+                    segfault  => Optional[Int],
+                ],
+            ],
+        ],
+    ],
+    default                       => undef,
+    documentation                 => "...",
+);
+
+package main;
+my $obj = Class->new();
+
+1;
+


### PR DESCRIPTION
This'll segfault due to this code in the XS code running out of bounds:

   2035:    char called_subname_pv[500];    /* XXX */
   2037:    char subr_call_key[500]; /* XXX */

I couldn't figure out how to make this test actually fail, even though
we segfault trying to run it.

Example output:
    
    $ /home/avar/perl5/installed/bin/prove5.21.9 -b -v t/73-moose-long-type-name.t 
    ok 1 - Found nytprofcsv as ../blib/script/nytprofcsv
    panic: called_subname_pv buffer overflow on 'Maybe[MooseX::Types::Structured::Dict[some,Int,really,ArrayRef[MooseX::Types::Structured::Dict[long,MooseX::Types::Structured::Optional[Int],typecheck,MooseX::Types::Structured::Optional[Str],that,MooseX::Types::Structured::Optional[Str],seems,MooseX::Types::Structured::Optional[Str],to,MooseX::Types::Structured::Optional[Str],go,MooseX::Types::Structured::Optional[Str],on,MooseX::Types::Structured::Optional[Int],forever,MooseX::Types::Structured::Optional[Str],and,MooseX::Types::Structured::Optional[Bool],just,MooseX::Types::Structured::Optional[Int],never,MooseX::Types::Structured::Optional[Str],stops,MooseX::Types::Structured::Optional[Maybe[Str]],this,MooseX::Types::Structured::Optional[Int],used,MooseX::Types::Structured::Optional[Int],to,MooseX::Types::Structured::Optional[Int],cause,MooseX::Types::Structured::Optional[Int],a,MooseX::Types::Structured::Optional[Int],segfault,MooseX::Types::Structured::Optional[Int]]]]]'
    bad fid_lines_hv format 'Maybe[MooseX::Types::Structured::Dict[some,Int,really,ArrayRef[MooseX::Types::Structured::Dict[long,MooseX::Types::Structured::Optional[Int],typecheck,MooseX::Types::Structured::Optional[Str],that,Mo'
    bad fid_lines_hv format 'Maybe[MooseX::Types::Structured::Dict[some,Int,really,ArrayRef[MooseX::Types::Structured::Dict[long,MooseX::Types::Structured::Optional[Int],typecheck,MooseX::Types::Structured::Optional[Str],that,Mo'
    bad fid_lines_hv format 'Maybe[MooseX::Types::Structured::Dict[some,Int,really,ArrayRef[MooseX::Types::Structured::Dict[long,MooseX::Types::Structured::Optional[Int],typecheck,MooseX::Types::Structured::Optional[Str],that,Mo'
    Exit status 2304 from /home/avar/perl5/installed/bin/perl5.21.9 -d:NYTProf at t/73-moose-long-type-name.t line 28.
