### PR TITLE
fallback to checking PATH for nytprof scripts

### DIFF
--- a/bin/nytprofhtml
+++ b/bin/nytprofhtml
@@ -36,6 +36,7 @@ use Getopt::Long;
 use List::Util qw(sum max);
 use File::Copy;
 use File::Spec;
+use File::Which qw(which);
 use File::Path qw(rmtree);
 
 # Handle --profself before loading Devel::NYTProf::Core
@@ -70,8 +71,18 @@ my $json_any = eval { require JSON::Any; JSON::Any->import; JSON::Any->new }
     or warn "Can't load JSON::Any module - HTML visualizations skipped.\n";
 
 my $script_ext   = ($^O eq "MSWin32") ? "" : ".pl";
+
 my $nytprofcalls = File::Spec->catfile($Config{'bin'}, 'nytprofcalls');
+$nytprofcalls    = which 'nytprofcalls' if not -e $nytprofcalls;
+
+die "Unable to find nytprofcalls in $Config{bin} or on the PATH"
+    unless $nytprofcalls;
+
 my $flamegraph   = File::Spec->catfile($Config{'bin'}, 'flamegraph') . $script_ext;
+$flamegraph      = which "flamegraph$script_ext" if not -e $flamegraph;
+
+die "Unable to find flamegraph$script_ext in $Config{bin} or on the PATH"
+    unless $flamegraph;
 
 my @treemap_colors = (0,2,4,6,8,10,1,3,5,7,9);
 


### PR DESCRIPTION
nytprof scripts may not be installed to the main Perl installation bin
(e.g. when using perlbrew locallibs). If the scripts don't exist in
$Config{bin} check the PATH, and if they still can't be found die.