### PR TITLE
PERL_DISABLE_PMC might be anywhere, not in CCFLAGS

### DIFF
--- a/t/test40pmc.t
+++ b/t/test40pmc.t
@@ -1,8 +1,18 @@
 use strict;
 use Test::More;
 use Config;
+
+my $no_pmc;
+if (Config->can('non_bincompat_options')) {
+    foreach(Config::non_bincompat_options()) {
+       if($_ eq "PERL_DISABLE_PMC"){
+           $no_pmc = 1;
+           last;
+       }
+    }
+};
 plan skip_all => ".pmc are disabled in this perl"
-    if $Config{ccflags} =~ /(?<!\w)-DPERL_DISABLE_PMC\b/;
+    if $no_pmc;
 use lib qw(t/lib);
 use NYTProfTest;
 


### PR DESCRIPTION
from https://metacpan.org/source/CORION/parent-0.231/t/parent-pmc.t which recently got a PMC fix by me