### PR TITLE
Add QueryPerformanceCounter clock for Windows

### DIFF
--- a/Changes
+++ b/Changes
@@ -7,6 +7,7 @@ Devel::NYTProf::Changes - History of significant changes in Devel::NYTProf
 =head2 Changes in Devel::NYTProf
 
   Fallback to checking PATH for nytprof scripts, #61 thanks to calid.
+  Changed Windows clock to QueryPerformanceCounter for more resolution.
 
 =head2 Changes in Devel::NYTProf 5.07 - 21st Feb 2015
 

--- a/lib/Devel/NYTProf.pm
+++ b/lib/Devel/NYTProf.pm
@@ -1101,6 +1101,8 @@ impacted by those more than it otherwise would.
 
 =head3 Windows
 
+B<THIS SECTION DOESN'T MATCH THE CODE>
+
 On Windows NYTProf uses Time::HiRes which uses the windows
 QueryPerformanceCounter() API with some extra logic to adjust for the current
 clock speed and try to resync the raw counter to wallclock time every so often


### PR DESCRIPTION
This patch fixes the issues in https://github.com/timbunce/devel-nytprof/issues/31 (I tested the new patch on VC 2003, VC 6 and Strawberry Perl/GCC). The QPC code in https://github.com/timbunce/devel-nytprof/pull/26 was never merged due to the 

```
The sum of the statement timings is 1.$% of the total time profiling. (Values sl
ightly over 100% can be due simply to cumulative timing errors, whereas larger v
alues can indicate a problem with the clock used.)
Summary: statements profiled 16 (=16-0), sum of time 0.000225s, profile spanned
0.000000s
```
problem. I think the easiest way to fix that is special case it, that if the gettimeofday duration of the NYTProf run is 0.0 after using QPC clock, just ignore that it is 0.0 and dont issue a warning, which is what I did in this patch. There is no point in trying to test QPC's accuracy, with QPC.