### PR TITLE
use setvbuf to increase buffer size

### DIFF
--- a/FileHandle.xs
+++ b/FileHandle.xs
@@ -215,6 +215,9 @@ NYTP_open(const char *name, const char *mode) {
     if (!raw_file)
         return NULL;
 
+/* MS libc has 4096 as default, this is too slow for GB size profiling data */
+    if (setvbuf(raw_file, NULL, _IOFBF, 16384))
+        return NULL;
     Newx(file, 1, struct NYTP_file_t);
     file->file = raw_file;
 


### PR DESCRIPTION
512(a disk sector)-8096(glibc) are typical amounts, go higher than that