### PR TITLE
Context fixes

### DIFF
--- a/FileHandle.xs
+++ b/FileHandle.xs
@@ -240,6 +240,7 @@ NYTP_open(const char *name, const char *mode) {
 
 static void
 grab_input(NYTP_file ifile) {
+    dNFTHX(ifile);
     ERRNO_PROBE;
 
     ifile->count = 0;
@@ -260,7 +261,6 @@ grab_input(NYTP_file ifile) {
             if (got == 0) {
                 if (!feof(ifile->file)) {
                     int eno = errno;
-                    dNFTHX(ifile);
                     croak("grab_input failed: %d (%s)", eno, strerror(eno));
                 }
                 ifile->stdio_at_eof = TRUE;
@@ -443,6 +443,7 @@ NYTP_gets(NYTP_file ifile, char **buffer_p, size_t *len_p) {
    (and hopefully the underlying OS block writes).  */
 static void
 sync_avail_out_to_ftell(NYTP_file ofile) {
+    dNFTHX(ofile);
     const long result = ftell(ofile->file);
     const unsigned long where = result < 0 ? 0 : result;
     ERRNO_PROBE;
@@ -457,6 +458,7 @@ sync_avail_out_to_ftell(NYTP_file ofile) {
 /* flush has values as described for "allowed flush values" in zlib.h  */
 static void
 flush_output(NYTP_file ofile, int flush) {
+    dNFTHX(ofile);
     ERRNO_PROBE;
 
     ofile->zs.next_in = (Bytef *) ofile->large_buffer;
@@ -502,7 +504,6 @@ flush_output(NYTP_file ofile, int flush) {
                         avail -= count;
                     } else {
                         int eno = errno;
-                        dNFTHX(ofile);
                         croak("fwrite in flush error %d: %s", eno,
                               strerror(eno));
                     }

--- a/FileHandle.xs
+++ b/FileHandle.xs
@@ -987,7 +987,7 @@ NYTP_write_option_iv(NYTP_file ofile, const char *key, IV value)
 {
     /* 3: 1 for rounding errors, 1 for the sign, 1 for the '\0'  */
     char buffer[(int)(sizeof (IV) * CHAR_BIT * LOG_2_OVER_LOG_10 + 3)];
-    const size_t len = my_snprintf(buffer, sizeof(buffer), "%ld", value);
+    const size_t len = my_snprintf(buffer, sizeof(buffer), "%"IVdf, value);
 
     return NYTP_write_option_pv(ofile, key, buffer, len);
 }

--- a/NYTProf.xs
+++ b/NYTProf.xs
@@ -1903,7 +1903,7 @@ reinit_if_forked(pTHX)
 
     /* we're now the child process */
     if (trace_level >= 1)
-        logwarn("~ new pid %d (was %d) forkdepth %ld\n", getpid(), last_pid, profile_forkdepth);
+        logwarn("~ new pid %d (was %d) forkdepth %"IVdf"\n", getpid(), last_pid, profile_forkdepth);
 
     /* reset state */
     last_pid = getpid();
@@ -3029,7 +3029,7 @@ disable_profile(pTHX)
         is_profiling = 0;
     }
     if (trace_level)
-        logwarn("~ disable_profile (previously %s, pid %d, trace %ld)\n",
+        logwarn("~ disable_profile (previously %s, pid %d, trace %"IVdf")\n",
             prev_is_profiling ? "enabled" : "disabled", getpid(), trace_level);
     return prev_is_profiling;
 }
@@ -4400,7 +4400,7 @@ load_pid_start_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ..
     (void)hv_store(state->live_pids_hv, text, len, newSVuv(ppid), 0);
     if (trace_level)
         logwarn("Start of profile data for pid %s (ppid %d, %"IVdf" pids live) at %"NVff"\n",
-                text, ppid, HvKEYS(state->live_pids_hv), start_time);
+                text, ppid, (IV)HvKEYS(state->live_pids_hv), start_time);
 
     store_attrib_sv(aTHX_ state->attr_hv, STR_WITH_LEN("profiler_start_time"),
                     newSVnv(start_time));
@@ -4432,7 +4432,7 @@ load_pid_end_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
                 pid);
     if (trace_level)
         logwarn("End of profile data for pid %s (%"IVdf" remaining) at %"NVff"\n", text,
-                HvKEYS(state->live_pids_hv), state->profiler_end_time);
+                (IV)HvKEYS(state->live_pids_hv), state->profiler_end_time);
 
     store_attrib_sv(aTHX_ state->attr_hv, STR_WITH_LEN("profiler_end_time"),
                     newSVnv(end_time));
@@ -5003,7 +5003,7 @@ load_profile_to_hv(pTHX_ NYTP_file in)
 
     if (HvKEYS(state.live_pids_hv)) {
         logwarn("Profile data incomplete, no terminator for %"IVdf" pids %s\n",
-            HvKEYS(state.live_pids_hv),
+            (IV)HvKEYS(state.live_pids_hv),
             "(refer to TROUBLESHOOTING in the documentation)");
         store_attrib_sv(aTHX_ state.attr_hv, STR_WITH_LEN("complete"),
                         &PL_sv_no);


### PR DESCRIPTION
The context fixes are required to compile under PERL_IMPLICIT_CONTEXT with HAS_ZLIB.
