### PR TITLE
NYTProf.xs: o->op_sibling -> OpSIBLING(o)

### DIFF
--- a/NYTProf.xs
+++ b/NYTProf.xs
@@ -1547,7 +1547,7 @@ closest_cop(pTHX_ const COP *cop, const OP *o)
         return cop;
     if (o->op_flags & OPf_KIDS) {
         const OP *kid;
-        for (kid = cUNOPo->op_first; kid; kid = kid->op_sibling) {
+        for (kid = cUNOPo->op_first; kid; kid = OpSIBLING(kid)) {
             const COP *new_cop;
             /* If the OP_NEXTSTATE has been optimised away we can still use it
              * the get the file and line number. */
@@ -1613,7 +1613,7 @@ DB_stmt(pTHX_ COP *cop, OP *op)
          * cop by searching through the optree starting from the sibling of PL_curcop.
          * See Perl_vmess in perl's util.c for how warn("...") finds the line number.
          */
-        cop = (COP*)closest_cop(aTHX_ cop, cop->op_sibling);
+        cop = (COP*)closest_cop(aTHX_ cop, OpSIBLING(cop));
         if (!cop)
             cop = PL_curcop_nytprof;
         last_executed_line = CopLINE(cop);

--- a/NYTProf.xs
+++ b/NYTProf.xs
@@ -187,6 +187,13 @@ Perl_gv_fetchfile_flags(pTHX_ const char *const name, const STRLEN namelen, cons
 static PerlInterpreter *orig_my_perl;
 #endif
 
+/* op->op_sibling is deprecated on new perls, but the OpSIBLING macro doesn't
+   exist on older perls. We don't need to check for PERL_OP_PARENT here
+   because if PERL_OP_PARENT was set, and we needed to check op_moresib,
+   we would already have this macro. */
+#ifndef OpSIBLING
+#define OpSIBLING(o) (0 + (o)->op_sibling)
+#endif
 
 #define MAX_HASH_SIZE 512
 


### PR DESCRIPTION
The Perl core, since 586d4abb8, has had a build mode called PERL_OP_PARENT, which causes the last sibling in a sibling chain to use op_sibling to point to the parent, rather than being null. Under this build mode, op_sibling is now called op_sibparent. Devel::NYTProf (incorrectly) uses the struct field op->sibling directly rather than using a macro. This is now causing NYTProf `make` to fail with a compile error.

The name of the field was changed to force programs using op_sibling to revisit their code in light of this change - now, the last sibling in a chain will have a non-NULL op_sibparent, and the caller must use op_moresib to know whether the pointer is to another sibling or to the parent.

This breakage is now visible in bleadperl, since PERL_OP_PARENT was made default, and will be default in 5.26.0. op.h provides a macro, OpSIBLING(o), which behaves correctly, checking op->moresib under PERL_OP_PARENT, and returning either op_sibparent or NULL. This patch replaces op_sibling with use that macro.

With this patch, Devel::NYTProf passes all tests on 5.24.0 without PERL_OP_PARENT, as well as on perlblead with PERL_OP_PARENT.