### PR TITLE
Fix for the double opening of the web browser

### DIFF
--- a/bin/nytprofhtml
+++ b/bin/nytprofhtml
@@ -1321,7 +1321,8 @@ sub _copy_dir {
 sub open_browser_on {
     my $index = shift;
 
-    return if eval { require Browser::Open; Browser::Open::open_browser($index, 1); };
+    my $exit_code = eval { require Browser::Open; Browser::Open::open_browser($index, 1); };
+    return if defined($exit_code) && $exit_code == 0;
     warn "$@\n" if $@ && $opt_debug;
 
     return if eval { require ActiveState::Browser; ActiveState::Browser::open($index); 1 };


### PR DESCRIPTION
#### Fix for the double opening of the web browser

When [Browser::Open](https://metacpan.org/pod/Browser::Open) is available and it opens a browser, it returns the result of `system()` ([source code](https://metacpan.org/source/CFRANKS/Browser-Open-0.04/lib/Browser/Open.pm#L72)), which is the exit code of the process. On success, the exit code is zero. We now check for this and return without trying to open the browser again.

Previously, the browser was opening twice when the `--open` flag was provided.