### PR TITLE
Fix test failures on Perl 5.26 w/ PERL_USE_UNSAFE_INC=0

### DIFF
--- a/t/lib/NYTProfTest.pm
+++ b/t/lib/NYTProfTest.pm
@@ -69,6 +69,10 @@ my $text_extn_info = {
     pf    => { order => 50, tests => 2, },
 };
 
+# having t/* in @INC is necessary for prefix-stripping
+# to reduce test-file names down to the single tokens
+# that are used in the comparison-output files.
+unshift @INC, File::Spec->rel2abs('./t') if -d 't';
 chdir('t') if -d 't';
 
 if (-d '../blib') {


### PR DESCRIPTION
Perl 5.26+ removes '.' from the default `@INC`, and this breaks the
mechanism internally where `@INC`-prefixes are stripped from fid_fileinfo
names ( in ::FileInfo.pm ).

This breaks tests due to the sample 'rdt' files expecting single-token
comparators relative to 't/', instead getting a fully qualified path in
the "got" side of the test.

This remedies this by ensuring a fully-qualified path to "t/" is in
`@INC` for the aforementioned prefix-stripper to pick-up on.

Closes: https://github.com/timbunce/devel-nytprof/issues/108
Bug: https://bugs.gentoo.org/615734