### PR TITLE
NYTProf.xs: prevent memory corruption in incr_sub_inclusive_time

### DIFF
--- a/NYTProf.xs
+++ b/NYTProf.xs
@@ -2153,7 +2153,7 @@ incr_sub_inclusive_time(pTHX_ subr_entry_t *subr_entry)
     /* exclusive = inclusive - time spent in subroutines called by this subroutine */
     excl_subr_ticks = incl_subr_ticks - called_sub_ticks;
 
-    subr_call_key_len = sprintf(subr_call_key, "%s::%s[%u:%d]",
+    subr_call_key_len = snprintf(subr_call_key, sizeof(subr_call_key), "%s::%s[%u:%d]",
         subr_entry->caller_subpkg_pv,
         (subr_entry->caller_subnam_sv) ? SvPV_nolen(subr_entry->caller_subnam_sv) : "(null)",
         subr_entry->caller_fid, subr_entry->caller_line);


### PR DESCRIPTION
In incr_sub_inclusive_time, the write to subr_call_key could in some
circumstances write beyond the size of the buffer:
  *** buffer overflow detected ***: /usr/sbin/uwsgi terminated
  ======= Backtrace: =========
  /lib64/libc.so.6(__fortify_fail+0x37)[0x7fb2c7589d87]
  /lib64/libc.so.6(+0x10df40)[0x7fb2c7587f40]
  /lib64/libc.so.6(+0x10d449)[0x7fb2c7587449]
  /lib64/libc.so.6(_IO_default_xsputn+0xbc)[0x7fb2c74f264c]
  /lib64/libc.so.6(_IO_vfprintf+0x151d)[0x7fb2c74c269d]
  /lib64/libc.so.6(__vsprintf_chk+0x88)[0x7fb2c75874d8]
  /lib64/libc.so.6(__sprintf_chk+0x7d)[0x7fb2c758742d]
  /usr/local/git_tree/main/lib/site/lib/auto/Devel/NYTProf/NYTProf.so(+0xe483)[0x7fb2ad9f0483]
  /usr/local/booking-perl/5.24.3/lib/CORE/libperl.so(Perl_leave_scope+0x116)[0x7fb2c54fc3b6]

With gdb attached I could find the function:
  #10 0x00007faa38ff1363 in incr_sub_inclusive_time () from /usr/lib/pakket/5.24.3/libraries/active/lib/perl5/x86_64-linux/auto/Devel/NYTProf/NYTProf.so

Notably, the crash didn't happen with optimizations disabled, with the -g to
Makefile.PL.

There's already a check for not exceeding the size of the buffer, but that
comes after the memory corruption happens.

Changing from sprintf to snprinf fixes the memory corruption, and will return
the number of bytes that *would* have been written if enough space was
available, so the check for size still happens.