### PR TITLE
Add appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,6 +16,7 @@ install:
 
 
 build_script:
+  - perl Makefile.PL
   - gmake
   - gmake test
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+branches:
+  except:
+    - /travis/
+skip_tags: true
+
+cache:
+  - C:\strawberry
+
+install:
+  - if not exist "C:\strawberry" choco install strawberryperl --version 5.26.1.1
+  - set ST=C:\strawberry
+  - set PATH=%ST%\perl\bin;%ST%\perl\site\bin;%ST%\c\bin;%PATH%
+  - cd C:\projects\%APPVEYOR_PROJECT_NAME%
+  
+  - cpanm --installdeps --notest --with-all-features .
+
+
+build_script:
+  - gmake
+  - gmake test
+


### PR DESCRIPTION
Add appveyor config file for CI on windows.

The default perl in Appveyor is currently 5.20.1.2000 x86.  This config file installs and uses 5.26.1 x64.

