### PR TITLE
Fix sorting of numbers ending ...5s as microsec

### DIFF
--- a/bin/nytprofhtml
+++ b/bin/nytprofhtml
@@ -1676,7 +1676,7 @@ EOD
             // console.log(orig);
             var val = orig.replace(/ns/,'');
             if (val != orig) { return val / (1000*1000*1000); }
-            val = orig.replace(/[µ\\xB5]s/,''); /* micro */
+            val = orig.replace(/[µ\xB5]s/,''); /* micro */
             if (val != orig) { return val / (1000*1000); }
             val = orig.replace(/ms/,'');
             if (val != orig) { return val / (1000); }


### PR DESCRIPTION
All numbers ending `5s` was handled as in µs. Actually, anything containing `\s`, `xs`, `Bs` or `5s` was handled as a time in µs.