### PR TITLE
For version 6.07 -- assuming we're including bin/flamegraph.pl changes

### DIFF
--- a/Changes
+++ b/Changes
@@ -4,6 +4,29 @@ Devel::NYTProf::Changes - History of significant changes in Devel::NYTProf
 
 =cut
 
+=head2 Changes in Devel::NYTProf 6.07 - 5th April 2020
+
+  Focus is to enable test suite to pass with perl-5.33.3 and higher.  (Changes
+    in blead required changes in expectations set in test data files.)
+
+  Correction to MANIFEST
+    thanks to mattlaw. #142
+
+  POD improvements
+    thanks to tomhukins. #129
+
+  Makefile.PL modernizations
+    thanks to karenetheridge. #126
+
+  .gitignore corrections
+    thanks to jkeenan. #146
+
+  Adapt tests to work with 5.33 and higher
+    thanks to jkeenan. #147 
+
+  Update flamegraph.pl
+    thanks to versable. #130
+
 =head2 Changes in Devel::NYTProf 6.06 - 4th June 2018
 
   Fix sorting of numbers ending ...5s as microsec

--- a/HACKING
+++ b/HACKING
@@ -12,18 +12,19 @@ http://metacpan.org/release/Devel-NYTProf/
 
 OBTAINING THE LATEST DEVELOPMENT CODE
 -------------------------------------
-You can grab the head of the latest trunk code from the Google Code repository, see
-http://code.google.com/p/perl-devel-nytprof/source/checkout
+You can grab the head of the latest trunk code from the GitHub repository.  See:
+https://github.com/timbunce/devel-nytprof
 
 CONTRIBUTING
 ------------
 Please work with the latest code from the repository - see above.
 
-Small patches can be uploaded via the issue tracker at
-http://code.google.com/p/perl-devel-nytprof/issues/list
+To report bugs or to discuss Devel-NYTProf's ongoing development,
+please file an issue at:
+https://github.com/timbunce/devel-nytprof/issues
 
-For larger changes please talk to us first via the mailing list at
-http://code.google.com/p/perl-devel-nytprof/source/checkout
+Please submit patches via pull requests at:
+https://github.com/timbunce/devel-nytprof/pulls
 
 When developing, please ensure that no new compiler warnings are output.
 
@@ -34,6 +35,10 @@ Please try to add tests covering any changes you make.
 You can run individual tests like this:
 
   perl -Mblib t/30-util.t
+
+... or:
+
+  prove -vb t/30-util.t
 
 Most tests include some underlying perl code that's being profiled.
 Either as a .p file, which can be profiled like this:
@@ -48,14 +53,8 @@ The output will be in the ./nytprof.out file.
 
 RESOURCES
 ---------
-Google Code:
-http://code.google.com/p/perl-devel-nytprof/
-
 Google Devel Group (must subscribe here):
 http://groups.google.com/group/develnytprof-dev
-
-NYTimes Open Code Blog:
-http://open.nytimes.com/
 
 TODO (unsorted, unprioritized, unconsidered, even unreasonable and daft :)
 ----

--- a/bin/nytprofcalls
+++ b/bin/nytprofcalls
@@ -14,7 +14,7 @@ use strict;
 use Devel::NYTProf::Core;
 require Devel::NYTProf::Data;
 
-our $VERSION = '6.06';
+our $VERSION = '6.07';
     
 use Data::Dumper;
 use Getopt::Long;

--- a/bin/nytprofcsv
+++ b/bin/nytprofcsv
@@ -16,7 +16,7 @@ use Getopt::Long;
 
 use Devel::NYTProf::Reader;
 
-our $VERSION = '6.06';
+our $VERSION = '6.07';
 
 use constant NUMERIC_PRECISION => 5;
 

--- a/bin/nytprofhtml
+++ b/bin/nytprofhtml
@@ -61,7 +61,7 @@ use Devel::NYTProf::Util qw(
 );
 use Devel::NYTProf::Constants qw(NYTP_SCi_CALLING_SUB);
 
-our $VERSION = '6.06';
+our $VERSION = '6.07';
 
 if ($VERSION != $Devel::NYTProf::Core::VERSION) {
     die "$0 version '$VERSION' doesn't match version '$Devel::NYTProf::Core::VERSION' of $INC{'Devel/NYTProf/Core.pm'}\n";

--- a/bin/nytprofmerge
+++ b/bin/nytprofmerge
@@ -16,7 +16,7 @@ require Devel::NYTProf::FileHandle;
 require Devel::NYTProf::Data;
 use List::Util qw(min sum);
 
-our $VERSION = '6.06';
+our $VERSION = '6.07';
     
 if ($VERSION != $Devel::NYTProf::Core::VERSION) {
     die "$0 version '$VERSION' doesn't match version '$Devel::NYTProf::Core::VERSION' of $INC{'Devel/NYTProf/Core.pm'}\n";

--- a/bin/nytprofpf
+++ b/bin/nytprofpf
@@ -54,7 +54,7 @@ use Devel::NYTProf::Util qw(
 );
 use Devel::NYTProf::Constants qw(NYTP_SCi_CALLING_SUB);
 
-our $VERSION = '6.06';
+our $VERSION = '6.07';
 
 if ($VERSION != $Devel::NYTProf::Core::VERSION) {
     die "$0 version '$VERSION' doesn't match version '$Devel::NYTProf::Core::VERSION' of $INC{'Devel/NYTProf/Core.pm'}\n";

--- a/lib/Devel/NYTProf.pm
+++ b/lib/Devel/NYTProf.pm
@@ -9,7 +9,7 @@
 ###########################################################
 package Devel::NYTProf;
 
-our $VERSION = '6.06'; # also change in Devel::NYTProf::Core
+our $VERSION = '6.07'; # also change in Devel::NYTProf::Core
 
 package    # hide the package from the PAUSE indexer
     DB;

--- a/lib/Devel/NYTProf/Apache.pm
+++ b/lib/Devel/NYTProf/Apache.pm
@@ -9,7 +9,7 @@
 ###########################################################
 package Devel::NYTProf::Apache;
 
-our $VERSION = '4.00';
+our $VERSION = '6.07';
 
 BEGIN {
 

--- a/lib/Devel/NYTProf/Core.pm
+++ b/lib/Devel/NYTProf/Core.pm
@@ -12,7 +12,7 @@ package Devel::NYTProf::Core;
 
 use XSLoader;
 
-our $VERSION = '6.06';    # increment with XS changes too
+our $VERSION = '6.07';    # increment with XS changes too
 
 XSLoader::load('Devel::NYTProf', $VERSION);
 

--- a/lib/Devel/NYTProf/Data.pm
+++ b/lib/Devel/NYTProf/Data.pm
@@ -58,7 +58,7 @@ use Devel::NYTProf::Util qw(
     trace_level
 );
 
-our $VERSION = '4.02';
+our $VERSION = '6.07';
 
 
 =head2 new

--- a/lib/Devel/NYTProf/ReadStream.pm
+++ b/lib/Devel/NYTProf/ReadStream.pm
@@ -3,7 +3,7 @@ package Devel::NYTProf::ReadStream;
 use warnings;
 use strict;
 
-our $VERSION = '4.00';
+our $VERSION = '6.07';
 
 use base 'Exporter';
 our @EXPORT_OK = qw(

--- a/lib/Devel/NYTProf/Reader.pm
+++ b/lib/Devel/NYTProf/Reader.pm
@@ -9,7 +9,7 @@
 ###########################################################
 package Devel::NYTProf::Reader;
 
-our $VERSION = '4.06';
+our $VERSION = '6.07';
 
 use warnings;
 use strict;

--- a/lib/Devel/NYTProf/Util.pm
+++ b/lib/Devel/NYTProf/Util.pm
@@ -40,7 +40,7 @@ use Cwd qw(getcwd);
 use List::Util qw(sum);
 use Devel::NYTProf::Core;
 
-our $VERSION = '4.00';
+our $VERSION = '6.07';
 
 our @EXPORT_OK = qw(
     fmt_float


### PR DESCRIPTION
@timbunce, this p.r. is based on the assumption that we're releasing the Mar 18 2019 changes to bin/flamegraph.pl as part of CPAN 6.07.

Please let me know whether this is okay, as I cannot myself vouch for them.  If not, I will revert that commit prior to CPAN release.

Thank you very much.
Jim Keenan