### PR TITLE
Build time warnings 20210409

### DIFF
--- a/NYTProf.xs
+++ b/NYTProf.xs
@@ -3924,7 +3924,7 @@ typedef struct loader_state_base {
     unsigned long input_chunk_seqn;
 } Loader_state_base;
 
-typedef void (*loader_callback)(Loader_state_base *cb_data, const nytp_tax_index tag, ...);
+typedef void (*loader_callback)(Loader_state_base *cb_data, const int tag, ...);
 
 typedef struct loader_state_callback {
     Loader_state_base base_state;
@@ -3966,7 +3966,7 @@ typedef struct loader_state_profiler {
 } Loader_state_profiler;
 
 static void
-load_discount_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_discount_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     PERL_UNUSED_ARG(tag);
@@ -3982,7 +3982,7 @@ load_discount_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...
 }
 
 static void
-load_time_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_time_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4057,7 +4057,7 @@ load_time_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
 }
 
 static void
-load_new_fid_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_new_fid_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4153,7 +4153,7 @@ load_new_fid_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
 }
 
 static void
-load_src_line_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_src_line_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4188,7 +4188,7 @@ load_src_line_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...
 }
 
 static void
-load_sub_info_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_sub_info_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4253,7 +4253,7 @@ load_sub_info_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...
 }
 
 static void
-load_sub_callers_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_sub_callers_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4388,7 +4388,7 @@ load_sub_callers_callback(Loader_state_base *cb_data, const nytp_tax_index tag, 
 }
 
 static void
-load_pid_start_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_pid_start_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4420,7 +4420,7 @@ load_pid_start_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ..
 }
 
 static void
-load_pid_end_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_pid_end_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4456,7 +4456,7 @@ load_pid_end_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
 }
 
 static void
-load_attribute_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_attribute_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4487,7 +4487,7 @@ load_attribute_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ..
 }
 
 static void
-load_option_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_option_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_profiler *state = (Loader_state_profiler *)cb_data;
     dTHXa(state->interp);
@@ -4548,7 +4548,7 @@ static struct perl_callback_info_t callback_info[nytp_tag_max] =
 };
 
 static void
-load_perl_callback(Loader_state_base *cb_data, const nytp_tax_index tag, ...)
+load_perl_callback(Loader_state_base *cb_data, const int tag, ...)
 {
     Loader_state_callback *state = (Loader_state_callback *)cb_data;
     dTHXa(state->interp);

--- a/ppport.h
+++ b/ppport.h
@@ -4589,13 +4589,13 @@ typedef OP* (CPERLscope(*Perl_check_t)) (pTHX_ OP*);
 #  undef isPRINT
 # endif
 
-#ifdef HAS_QUAD
+#if defined(HAS_QUAD) && !defined(WIDEST_UTYPE)
 # ifdef U64TYPE
 #  define WIDEST_UTYPE U64TYPE
 # else
 #  define WIDEST_UTYPE Quad_t
 # endif
-#else
+#elif !defined(WIDEST_UTYPE)
 # define WIDEST_UTYPE U32
 #endif
 #ifndef isALNUMC


### PR DESCRIPTION
This pull request partially addresses the problem described in https://github.com/timbunce/devel-nytprof/issues/145.  It cherry-picks two commits submitted by @rurban in 2019 as part of https://github.com/timbunce/devel-nytprof/pull/134.

My local experimentation suggests that these commits eliminate all warnings but one that are generated during `make` when both `perl` and Devel::NYTProf are compiled with recent versions of `clang`, such as version 9 or 10.

Since those warnings are *not* generated during `make` when `perl` and Devel::NYTProf are compiled with recent `gcc`, the patches don't change anything in that case.

When, however, I compiled `perl` with a recent version of `g++` and then tried to install Devel::NYTProf, I found that the build processed failed with one of the module's  prerequisites, a bug which I have reported [upstream](https://github.com/rurban/Cpanel-JSON-XS/issues/177).

It would be good to have these patches reviewed by people more familiar with C than I am.  However, we'll defer application for a while in the hope that we can get the prerequisite's bug fixed.

Thank you very much.
Jim Keenan