### PR TITLE
Move unused code out of the way

### DIFF
--- a/NYTProf.xs
+++ b/NYTProf.xs
@@ -1210,20 +1210,6 @@ get_file_id(pTHX_ char* file_name, STRLEN file_name_len, int created_via)
 }
 
 
-/**
- * Return a unique persistent id number for a string.
- *
- * XXX Currently not used, so may trigger compiler warnings, but is intended to be
- * used to assign ids to strings like subroutine names like we do for file ids.
- */
-static unsigned int
-get_str_id(pTHX_ char* str, STRLEN len)
-{
-    str_hash_entry *found;
-    hash_op(&strhash, str, len, (Hash_entry**)&found, 1);
-    return found->he.id;
-}
-
 static UV
 uv_from_av(pTHX_ AV *av, int idx, UV default_uv)
 {

--- a/devstuff/superseded.pm
+++ b/devstuff/superseded.pm
@@ -1,0 +1,62 @@
+# 2021-03-31: packages_at_depth_subinfo() not found in distro
+# [
+#   undef,  # depth 0
+#   {       # depth 1
+#       "main::" => [ [ subinfo1, subinfo2 ] ],    # 2 subs in 1 pkg
+#       "Foo::"  => [ [ subinfo3 ], [ subinfo4 ] ] # 2 subs in 2 pkg
+#   }
+#   {       # depth 2
+#       "Foo::Bar::" => [ [ subinfo3 ] ]           # 1 sub in 1 pkg
+#       "Foo::Baz::" => [ [ subinfo4 ] ]           # 1 sub in 1 pkg
+#   }
+# ]
+#
+sub packages_at_depth_subinfo {
+    my $self = shift;
+    my ($opts) = @_;
+
+    my $merged = $opts->{merge_subinfos};
+    my $all_pkgs = $self->package_subinfo_map($merged) || {};
+
+    my @packages_at_depth = ({});
+    while ( my ($fullpkgname, $subinfos) = each %$all_pkgs ) {
+
+        $subinfos = [ grep { $_->calls } @$subinfos ]
+            if not $opts->{include_unused_subs};
+
+        next unless @$subinfos;
+
+        my @parts = split /::/, $fullpkgname; # drops empty trailing part
+
+        # accumulate @$subinfos for the full package name
+        # and also for each successive truncation of the package name
+        for (my $depth; $depth = @parts; pop @parts) {
+            my $pkgname = join('::', @parts, '');
+
+            my $store = ($merged) ? $subinfos->[0] : $subinfos;
+
+            # { "Foo::" => [ [sub1,sub2], [sub3,sub4] ] } # subs from 2 packages
+            my $pkgdepthinfo = $packages_at_depth[$depth] ||= {};
+            push @{ $pkgdepthinfo->{$pkgname} }, $store;
+
+            last if not $opts->{rollup_packages};
+        }
+    }
+    # fill in any undef holes at depths with no subs
+    $_ ||= {} for @packages_at_depth;
+
+    return \@packages_at_depth;
+}
+
+
+# 2021-03-31: package_fids() not exercised anywhere in distro
+sub package_fids {
+    my ($self, $package) = @_;
+    my @fids;
+    #warn "package_fids '$package'";
+    return @fids if wantarray;
+    warn "Package 'package' has items defined in multiple fids: @fids\n"
+        if @fids > 1;
+    return $fids[0];
+}
+

--- a/devstuff/superseded.xs
+++ b/devstuff/superseded.xs
@@ -1,0 +1,15 @@
+/**
+ * Return a unique persistent id number for a string.
+ *
+ * XXX Currently not used, so may trigger compiler warnings, but is intended to be
+ * used to assign ids to strings like subroutine names like we do for file ids.
+ */
+static unsigned int
+get_str_id(pTHX_ char* str, STRLEN len)
+{
+    str_hash_entry *found;
+    hash_op(&strhash, str, len, (Hash_entry**)&found, 1);
+    return found->he.id;
+}
+
+

--- a/lib/Devel/NYTProf/Data.pm
+++ b/lib/Devel/NYTProf/Data.pm
@@ -289,56 +289,6 @@ sub package_subinfo_map {
     return \%pkg;
 }
 
-# 2021-03-31: packages_at_depth_subinfo() not found in distro
-# [
-#   undef,  # depth 0
-#   {       # depth 1
-#       "main::" => [ [ subinfo1, subinfo2 ] ],    # 2 subs in 1 pkg
-#       "Foo::"  => [ [ subinfo3 ], [ subinfo4 ] ] # 2 subs in 2 pkg
-#   }
-#   {       # depth 2
-#       "Foo::Bar::" => [ [ subinfo3 ] ]           # 1 sub in 1 pkg
-#       "Foo::Baz::" => [ [ subinfo4 ] ]           # 1 sub in 1 pkg
-#   }
-# ]
-#
-#sub packages_at_depth_subinfo {
-#    my $self = shift;
-#    my ($opts) = @_;
-#
-#    my $merged = $opts->{merge_subinfos};
-#    my $all_pkgs = $self->package_subinfo_map($merged) || {};
-#
-#    my @packages_at_depth = ({});
-#    while ( my ($fullpkgname, $subinfos) = each %$all_pkgs ) {
-#
-#        $subinfos = [ grep { $_->calls } @$subinfos ]
-#            if not $opts->{include_unused_subs};
-#
-#        next unless @$subinfos;
-#
-#        my @parts = split /::/, $fullpkgname; # drops empty trailing part
-#
-#        # accumulate @$subinfos for the full package name
-#        # and also for each successive truncation of the package name
-#        for (my $depth; $depth = @parts; pop @parts) {
-#            my $pkgname = join('::', @parts, '');
-#
-#            my $store = ($merged) ? $subinfos->[0] : $subinfos;
-#
-#            # { "Foo::" => [ [sub1,sub2], [sub3,sub4] ] } # subs from 2 packages
-#            my $pkgdepthinfo = $packages_at_depth[$depth] ||= {};
-#            push @{ $pkgdepthinfo->{$pkgname} }, $store;
-#
-#            last if not $opts->{rollup_packages};
-#        }
-#    }
-#    # fill in any undef holes at depths with no subs
-#    $_ ||= {} for @packages_at_depth;
-#
-#    return \@packages_at_depth;
-#}
-
 sub all_fileinfos {
     my @all = @{shift->{fid_fileinfo}};
     shift @all;    # drop fid 0
@@ -813,17 +763,6 @@ sub resolve_fid {
 
     return undef;
 }
-
-# 2021-03-31: package_fids() not exercised anywhere in distro
-#sub package_fids {
-#    my ($self, $package) = @_;
-#    my @fids;
-#    #warn "package_fids '$package'";
-#    return @fids if wantarray;
-#    warn "Package 'package' has items defined in multiple fids: @fids\n"
-#        if @fids > 1;
-#    return $fids[0];
-#}
 
 1;
 


### PR DESCRIPTION
One function long present in NYTProf.xs was never used, but its lack of
use generates a build-time warning -- the last such warning currently
observed.  Move it to a file in the devstuff/ directory so that we can
access it in the future should we need to do so.

Similarly, two functions in Devel::NYTProf::Data were never used in
lib/, bin/ or t/, so let's similarly move them out of the way.