### PR TITLE
Test for compression via NYTP_ZLIB_VERSION

### DIFF
--- a/t/11-reader.t
+++ b/t/11-reader.t
@@ -5,13 +5,15 @@ use Devel::NYTProf::Reader;
 use Test::More;
 use File::Spec;
 use File::Temp qw( tempdir );
-
-# Relax this restriction once we figure out how to make test $file work for
-# Appveyor.
-plan skip_all => "doesn't work without HAS_ZLIB" if (($^O eq "MSWin32") || ($^O eq 'VMS'));
+use Devel::NYTProf::Constants qw(
+    NYTP_DEFAULT_COMPRESSION
+    NYTP_ZLIB_VERSION
+);
 
 my $file = "./t/nytprof_11-reader.out.txt";
 croak "No $file" unless -f $file;
+
+plan skip_all => "$file doesn't work unless NYTP_ZLIB_VERSION is set" unless NYTP_ZLIB_VERSION();
 
 # new()
 

--- a/t/12-data.t
+++ b/t/12-data.t
@@ -8,15 +8,17 @@ use File::Spec;
 use File::Temp qw( tempdir tempfile );
 use Data::Dumper;$Data::Dumper::Indent=1;
 use Capture::Tiny qw(capture_stdout capture_stderr );
-
-# Relax this restriction once we figure out how to make test $file work for
-# Appveyor.
-plan skip_all => "doesn't work without HAS_ZLIB" if (($^O eq "MSWin32") || ($^O eq 'VMS'));
-
-# General setup
+use Devel::NYTProf::Constants qw(
+    NYTP_DEFAULT_COMPRESSION
+    NYTP_ZLIB_VERSION
+);
 
 my $file = "./t/nytprof_12-data.out.txt";
 croak "No $file" unless -f $file;
+
+plan skip_all => "$file doesn't work unless NYTP_ZLIB_VERSION is set" unless NYTP_ZLIB_VERSION();
+
+# General setup
 
 my $reporter = Devel::NYTProf::Reader->new($file, { quiet => 1 });
 ok(defined $reporter, "Devel::NYTProf::Reader->new returned defined entity");

--- a/t/13-fileinfo.t
+++ b/t/13-fileinfo.t
@@ -3,16 +3,17 @@ use warnings;
 use Carp;
 use Devel::NYTProf::Data;
 use Test::More;
-use Data::Dumper;$Data::Dumper::Indent=1;
-
-# Relax this restriction once we figure out how to make test $file work for
-# Appveyor.
-plan skip_all => "doesn't work without HAS_ZLIB" if (($^O eq "MSWin32") || ($^O eq 'VMS'));
-
-# General setup
+use Devel::NYTProf::Constants qw(
+    NYTP_DEFAULT_COMPRESSION
+    NYTP_ZLIB_VERSION
+);
 
 my $file = "./t/nytprof_13-data.out.txt";
 croak "No $file" unless -f $file;
+
+plan skip_all => "$file doesn't work unless NYTP_ZLIB_VERSION is set" unless NYTP_ZLIB_VERSION();
+
+# General setup
 
 my $profile = Devel::NYTProf::Data->new({ filename => $file, quiet => 1 });
 ok(defined $profile, "Devel::NYTProf::Data->new() returned defined value");

--- a/t/14-subinfo.t
+++ b/t/14-subinfo.t
@@ -3,15 +3,17 @@ use warnings;
 use Carp;
 use Devel::NYTProf::Reader;
 use Test::More;
-
-# Relax this restriction once we figure out how to make test $file work for
-# Appveyor.
-plan skip_all => "doesn't work without HAS_ZLIB" if (($^O eq "MSWin32") || ($^O eq 'VMS'));
-
-# General setup
+use Devel::NYTProf::Constants qw(
+    NYTP_DEFAULT_COMPRESSION
+    NYTP_ZLIB_VERSION
+);
 
 my $file = "./t/nytprof_14-subinfo.out.txt";
 croak "No $file" unless -f $file;
+
+plan skip_all => "$file doesn't work unless NYTP_ZLIB_VERSION is set" unless NYTP_ZLIB_VERSION();
+
+# General setup
 
 my $reporter = Devel::NYTProf::Reader->new($file, { quiet => 1 });
 ok(defined $reporter, "Devel::NYTProf::Reader->new returned defined entity");


### PR DESCRIPTION
As suggested by Tinita in
https://github.com/timbunce/devel-nytprof/issues/169, this should be a
more precise test as to whether this build of perl/Devel-NYTProf can
handle compressed data in profiles.

Hopefully this will resolve https://github.com/timbunce/devel-nytprof/issues/163 as well.

Signed-off-by: James E Keenan <jkeenan@cpan.org>