### PR TITLE
Add 'test_author' 'make' target (and alias 'atest')

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -76,6 +76,7 @@ t/50-errno.t
 t/60-forkdepth.t
 t/70-subname.t
 t/80-version.t
+t/90-pod.t
 t/lib/NYTProfTest.pm
 t/nytprof_11-reader.out.txt
 t/nytprof_12-data.out.txt
@@ -251,7 +252,6 @@ xt/61-cputime.t
 xt/68-hashline.t
 xt/71-moose.t
 xt/72-autodie.t
-xt/90-pod.t
 xt/91-pod_coverage.t
 xt/92-file_port.t
 xt/test23-strevalxs.p

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -283,8 +283,6 @@ perltidy:
 ctidy_bcpp:
 	bcpp -f 2 -i 4 -bcl -qb 10 -ylcnc -yb NYTProf.xs
 
-NYTPROF_AUTHOR_TESTING=""
-NYTPROF_TEST_SHORT=""
 test_short:
 	NYTPROF_TEST_SHORT=1 NYTPROF_AUTHOR_TESTING=1 make test
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -283,9 +283,15 @@ perltidy:
 ctidy_bcpp:
 	bcpp -f 2 -i 4 -bcl -qb 10 -ylcnc -yb NYTProf.xs
 
+NYTPROF_AUTHOR_TESTING=""
 NYTPROF_TEST_SHORT=""
 test_short:
-	NYTPROF_TEST_SHORT=1 make test
+	NYTPROF_TEST_SHORT=1 NYTPROF_AUTHOR_TESTING=1 make test
+
+test_author:
+	NYTPROF_AUTHOR_TESTING=1 make test
+
+atest: test_author
 
 }
 }

--- a/t/12-data.t
+++ b/t/12-data.t
@@ -263,6 +263,7 @@ is(scalar(@noneval_fileinfos), 1, "got 1 noneval_fileinfo");
 
 {
     SKIP: {
+        skip "NYTPROF_AUTHOR_TESTING only", 3 unless $ENV{NYTPROF_AUTHOR_TESTING};
         skip "Bad interaction when trace_level is set", 3
             if trace_level();
         my $profile;

--- a/t/90-pod.t
+++ b/t/90-pod.t
@@ -1,7 +1,12 @@
 #!perl -w
 
 use Test::More;
-plan skip_all => "NYTPROF_AUTHOR_TESTING only" unless $ENV{NYTPROF_AUTHOR_TESTING};
+unless ($ENV{NYTPROF_AUTHOR_TESTING}) {
+    plan skip_all => "NYTPROF_AUTHOR_TESTING only";
+}
+else {
+    diag("Relevant envvar is true; proceeding to testing POD");
+}
 
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;

--- a/t/90-pod.t
+++ b/t/90-pod.t
@@ -1,6 +1,8 @@
 #!perl -w
 
 use Test::More;
+plan skip_all => "NYTPROF_AUTHOR_TESTING only" unless $ENV{NYTPROF_AUTHOR_TESTING};
+
 eval "use Test::Pod 1.00";
 plan skip_all => "Test::Pod 1.00 required for testing POD" if $@;
 


### PR DESCRIPTION
Add envvar NYTPROF_AUTHOR_TESTING.  'make test_author' and 'make atest'
will set this envvar true, thereby causing certain unit tests within the
test suite and/or test files to run only when needed by NYTProf
developers.

Accordingly, move 90-pod.t back into t/ from xt/, but have this run only
when NYTPROF_AUTHOR_TESTING is set.

This should have a favorable impact on
https://github.com/timbunce/devel-nytprof/issues/174.