### PR TITLE
No need to set this in Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -283,7 +283,6 @@ perltidy:
 ctidy_bcpp:
 	bcpp -f 2 -i 4 -bcl -qb 10 -ylcnc -yb NYTProf.xs
 
-NYTPROF_TEST_SHORT=""
 test_short:
 	NYTPROF_TEST_SHORT=1 make test
 


### PR DESCRIPTION
While diagnosing problems with .appveyor.yml in another branch, it
became apparent that setting NYTPROF_* in the Makefile *outside the
context of any particular target* may interfere with other objectives.