### PR TITLE
Fix typos in /bin report generators

### DIFF
--- a/bin/nytprofcalls
+++ b/bin/nytprofcalls
@@ -41,7 +41,7 @@ usage: [perl] nytprofcalls [opts] nytprof-file [...]
  --help,        -h         Print this message
  --verbose,     -v         Be more verbose
 
-This script of part of the Devel::NYTProf distribution.
+This script is part of the Devel::NYTProf distribution.
 See https://metacpan.org/release/Devel-NYTProf for details and copyright.
 END
     exit 0;

--- a/bin/nytprofcg
+++ b/bin/nytprofcg
@@ -107,7 +107,7 @@ usage: [perl] nytprofcg [opts]
  --out <file>,  -o <file>  Specify output file [default: nytprof.callgrind]
  --help,        -h         Print this message
 
-This script of part of the Devel::NYTProf distribution.
+This script is part of the Devel::NYTProf distribution.
 Released under the same terms as Perl 5.8.0
 See http://metacpan.org/release/Devel-NYTProf/
 END

--- a/bin/nytprofcsv
+++ b/bin/nytprofcsv
@@ -119,7 +119,7 @@ usage: [perl] nytprofcsv [opts]
  --delete,      -d         Delete the old fprofhtml output [uses --out]
  --help,        -h         Print this message
 
-This script of part of the Devel::NYTProf package
+This script is part of the Devel::NYTProf package
 See https://metacpan.org/pod/Devel::NYTProf
 END
 }

--- a/bin/nytprofhtml
+++ b/bin/nytprofhtml
@@ -128,7 +128,7 @@ usage: [perl] nytprofhtml [opts]
  --no-mergeevals           Disable merging of string evals
  --help,        -h         Print this message
 
-This script of part of the Devel::NYTProf distribution.
+This script is part of the Devel::NYTProf distribution.
 See http://metacpan.org/release/Devel-NYTProf/ for details and copyright.
 END
     return 0;

--- a/bin/nytprofmerge
+++ b/bin/nytprofmerge
@@ -387,7 +387,7 @@ usage: [perl] nytprofmerge [opts] nytprof-file [...]
  --help,        -h         Print this message
  --verbose,     -v         Be more verbose
 
-This script of part of the Devel::NYTProf distribution.
+This script is part of the Devel::NYTProf distribution.
 See https://metacpan.org/release/Devel-NYTProf for details and copyright.
 END
     exit 0;

--- a/bin/nytprofpf
+++ b/bin/nytprofpf
@@ -27,7 +27,7 @@ Options synopsis:
  --no-mergeevals           Disable merging of string evals
  --help,        -h         Print this message
 
-This script of part of the Devel::NYTProf distribution. Generate a report for plat_forms (L<http://www.plat-forms.org/>) from Devel::NYTProf data.
+This script is part of the Devel::NYTProf distribution. Generate a report for plat_forms (L<http://www.plat-forms.org/>) from Devel::NYTProf data.
 See http://metacpan.org/release/Devel-NYTProf/ for details and copyright.
 
 =encoding ISO8859-1
@@ -79,7 +79,7 @@ usage: [perl] nytprofpf [opts]
  --no-mergeevals           Disable merging of string evals
  --help,        -h         Print this message
 
-This script of part of the Devel::NYTProf distribution.
+This script is part of the Devel::NYTProf distribution.
 See http://metacpan.org/release/Devel-NYTProf/ for details and copyright.
 END
     return 0;


### PR DESCRIPTION
Noticed this typo in the output of `nytprofhtml -h`, turns out it's present in all of the report generators.