### PR TITLE
Remove reference to .travis-ci.org

### DIFF
--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -14,8 +14,6 @@
 ^change-version\.sh$
 ^appveyor\.yml$
 ^.appveyor\.yml$
-^travis\.yml$
-^.travis\.yml$
 ^FileHandle.c$
 ^FileHandle.o$
 ^NYTProf.bs$

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Devel::NYTProf is a powerful feature-rich source code profiler for Perl 5.
 
-[![Build Status](https://secure.travis-ci.org/timbunce/devel-nytprof.png)](http://travis-ci.org/timbunce/devel-nytprof)
-
 For more information see:
 
 * https://www.youtube.com/watch?v=T7EK6RZAnEA


### PR DESCRIPTION
For: https://github.com/timbunce/devel-nytprof/issues/201