### PR TITLE
Don't test given/when once deprecated

### DIFF
--- a/t/test16.t
+++ b/t/test16.t
@@ -4,6 +4,8 @@ use Test::More;
 use lib qw(t/lib);
 use NYTProfTest;
 
-plan skip_all => "needs perl >= 5.10" unless $] >= 5.010;
+#plan skip_all => "needs perl >= 5.10" unless $] >= 5.010;
+plan skip_all => "needs perl >= 5.10 and <= 5.36"
+    unless ($] >= 5.010 and $] <= 5.036);
 
 run_test_group;


### PR DESCRIPTION
'given' and 'when' were deprecated during the 5.37 development cycle (committed Feb 25 2023).  So the last perl production release for which we should test then was 5.36; skip thereafter.