### PR TITLE
Update link to Flame Graph info in nytprofhtml output

### DIFF
--- a/bin/nytprofhtml
+++ b/bin/nytprofhtml
@@ -845,7 +845,7 @@ sub output_index_page {
 
             print $fh qq{<div class="flamegraph">\n};
             print $fh qq{<object data="$call_stacks_svg" width="$opt_flame_width" type="image/svg+xml" >SVG not supported</object>\n};
-            print $fh qq{<p>The <a href="http://dtrace.org/blogs/brendan/2011/12/16/flame-graphs/">Flame Graph</a> above is a visualization of the time spent in <em>distinct call stacks</em>. The colors and x-axis position are not meaningful.</p>\n};
+            print $fh qq{<p>The <a href="https://www.brendangregg.com/flamegraphs.html">Flame Graph</a> above is a visualization of the time spent in <em>distinct call stacks</em>. The colors and x-axis position are not meaningful.</p>\n};
             print $fh qq{</div>\n};
             1;
         };


### PR DESCRIPTION
While investigating the profiling output on a project I'm working on I happened to notice that the link to Brendan Gregg's Flame Graph page was broken.  It seems that the new page is now on www.brendangregg.com (as implemented in this change).

The last snapshot on the internet archive to still point to the dtrace.org address is from November 2013:
https://web.archive.org/web/20131110195734/http://dtrace.org/blogs/brendan/2011/12/16/flame-graphs/ and the following snapshot in January 2014 points to the new address https://web.archive.org/web/20140121022436/http://www.brendangregg.com/FlameGraphs/cpuflamegraphs.html, which then seems to have morphed into the link I've used here.  Thus, I'm fairly sure that the link I've used to fix the broken one is correct.

This PR is submitted in the hope that it is helpful. If you want anything changed, please let me know and I'll be happy to update and resubmit as necessary :-)