### PR TITLE
Fix precedence warning in Reader.pm

### DIFF
--- a/lib/Devel/NYTProf/Reader.pm
+++ b/lib/Devel/NYTProf/Reader.pm
@@ -135,7 +135,7 @@ sub output_dir {
     my ($self, $dir) = @_;
     return $self->{output_dir} unless defined($dir);
     if (!mkdir $dir) {
-        confess "Unable to create directory $dir: $!\n" if !$! =~ /exists/;
+        confess "Unable to create directory $dir: $!\n" if $! !~ /exists/;
     }
     $self->{output_dir} = $dir;
 }


### PR DESCRIPTION
Change `!$! =~ /exists/` to `$! !~ /exists/` to resolve "Possible precedence problem between ! and pattern match" warning introduced in Perl 5.42.