### PR TITLE
Fix unused parameter warning in NYTP_fstrerror

### DIFF
--- a/FileHandle.xs
+++ b/FileHandle.xs
@@ -636,6 +636,7 @@ NYTP_fstrerror(NYTP_file file) {
 #endif
     {
         dNFTHX(file);
+        PERL_UNUSED_ARG(file);
         return strerror(errno);
     }
 }


### PR DESCRIPTION
Add PERL_UNUSED_ARG(file) to suppress -Wunused-parameter warning. The 'file' parameter may be unused depending on build configuration (HAS_ZLIB and PERL_IMPLICIT_CONTEXT).